### PR TITLE
Add static Appium XML report web app

### DIFF
--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -1,0 +1,15 @@
+body {
+  background: #fff;
+  color: #000;
+}
+
+header, footer {
+  background: none;
+  color: #000;
+}
+
+#locatorTable th, #locatorTable td {
+  border: 1px solid #000;
+}
+
+button { display: none; }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,63 @@
+body {
+  background: #121212;
+  color: #e0e0e0;
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+header, footer {
+  padding: 1rem;
+  background: #1f1f1f;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+h1 {
+  flex: 1 0 100%;
+}
+
+main {
+  padding: 1rem;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+#locatorTable {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#locatorTable th, #locatorTable td {
+  border: 1px solid #333;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+#locatorTable th {
+  background: #222;
+}
+
+.issue-warning {
+  color: #ffb74d;
+}
+
+.issue-bad {
+  color: #e57373;
+}
+
+button {
+  background: #333;
+  color: #e0e0e0;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #444;
+}

--- a/assets/js/analyzer.js
+++ b/assets/js/analyzer.js
@@ -1,0 +1,47 @@
+import { parseBounds, isGenericId } from './utils.js';
+
+export function analyze(elements) {
+  const summary = {
+    total: elements.length,
+    withAccessibilityId: elements.filter(e => e.accId).length,
+    withId: elements.filter(e => e.id).length
+  };
+
+  const issues = { warnings: [], bads: [] };
+  const idMap = new Map();
+  const accMap = new Map();
+
+  elements.forEach(el => {
+    if (!el.accId) {
+      issues.warnings.push({ type: 'missingAccId', message: 'Missing accessibility id', element: el });
+    }
+    if (el.clickable && !el.id) {
+      issues.warnings.push({ type: 'missingId', message: 'Interactive element missing id', element: el });
+    }
+    if (el.id && isGenericId(el.id)) {
+      issues.warnings.push({ type: 'genericId', message: `Generic id ${el.id}`, element: el });
+    }
+    if (el.id) {
+      if (idMap.has(el.id)) {
+        issues.bads.push({ type: 'duplicateId', message: `Duplicate id ${el.id}`, element: el });
+      } else {
+        idMap.set(el.id, true);
+      }
+    }
+    if (el.accId) {
+      if (accMap.has(el.accId)) {
+        issues.bads.push({ type: 'duplicateAccId', message: `Duplicate accessibility id ${el.accId}`, element: el });
+      } else {
+        accMap.set(el.accId, true);
+      }
+    }
+    if (el.bounds) {
+      const { width, height } = parseBounds(el.bounds);
+      if (width < 48 || height < 48) {
+        issues.warnings.push({ type: 'smallTouch', message: `Small touch target ${width}x${height}`, element: el });
+      }
+    }
+  });
+
+  return { summary, issues, elements };
+}

--- a/assets/js/exports.js
+++ b/assets/js/exports.js
@@ -1,0 +1,24 @@
+function download(filename, content, type) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function exportCsv(elements) {
+  const header = 'type,id,accessibility_id,bounds';
+  const rows = elements.map(e => `${e.type},${e.id},${e.accId},"${e.bounds}"`);
+  const csv = [header, ...rows].join('\n');
+  download('report.csv', csv, 'text/csv');
+}
+
+export function exportJson(data) {
+  download('report.json', JSON.stringify(data, null, 2), 'application/json');
+}
+
+export function printReport() {
+  window.print();
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,3 @@
+import { setupUI } from './ui.js';
+
+setupUI();

--- a/assets/js/parser.js
+++ b/assets/js/parser.js
@@ -1,0 +1,32 @@
+export function parse(xml) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xml, 'text/xml');
+  const elements = [];
+
+  function traverse(node) {
+    if (node.nodeType !== 1) return; // element nodes only
+    const el = node;
+    const id = el.getAttribute('resource-id') || el.getAttribute('name') || '';
+    const accId = el.getAttribute('content-desc') || el.getAttribute('label') || el.getAttribute('accessibility-id') || '';
+    let bounds = el.getAttribute('bounds') || '';
+    if (!bounds && el.getAttribute('x') !== null) {
+      const x = parseFloat(el.getAttribute('x'));
+      const y = parseFloat(el.getAttribute('y'));
+      const width = parseFloat(el.getAttribute('width'));
+      const height = parseFloat(el.getAttribute('height'));
+      bounds = `[${x},${y}][${x + width},${y + height}]`;
+    }
+    const clickable = el.getAttribute('clickable') === 'true' || /Button/i.test(el.tagName);
+    elements.push({
+      type: el.tagName,
+      id,
+      accId,
+      bounds,
+      clickable
+    });
+    Array.from(el.children).forEach(traverse);
+  }
+
+  traverse(doc.documentElement);
+  return elements;
+}

--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -1,0 +1,31 @@
+import { chunk } from './utils.js';
+
+export function renderSummary(summary, container) {
+  container.innerHTML = `
+    <h2>Summary</h2>
+    <p>Total elements: ${summary.total}</p>
+    <p>With accessibility id: ${summary.withAccessibilityId}</p>
+    <p>With id: ${summary.withId}</p>
+  `;
+}
+
+export function renderIssues(issues, container) {
+  const warnItems = issues.warnings.map(i => `<li class="issue-warning">${i.message}</li>`).join('');
+  const badItems = issues.bads.map(i => `<li class="issue-bad">${i.message}</li>`).join('');
+  container.innerHTML = `
+    <h2>Issues</h2>
+    <h3>Warnings</h3>
+    <ul>${warnItems || '<li>None</li>'}</ul>
+    <h3>Bad</h3>
+    <ul>${badItems || '<li>None</li>'}</ul>
+  `;
+}
+
+export function renderTable(elements, tbody) {
+  tbody.innerHTML = '';
+  chunk(elements, el => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${el.type}</td><td>${el.id}</td><td>${el.accId}</td><td>${el.bounds}</td>`;
+    tbody.appendChild(tr);
+  });
+}

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -1,0 +1,50 @@
+import { parse } from './parser.js';
+import { analyze } from './analyzer.js';
+import { renderSummary, renderIssues, renderTable } from './renderer.js';
+import { exportCsv, exportJson, printReport } from './exports.js';
+
+export function setupUI() {
+  const fileInput = document.getElementById('xmlFile');
+  const androidBtn = document.getElementById('loadAndroidSample');
+  const iosBtn = document.getElementById('loadIosSample');
+  const summaryEl = document.getElementById('summary');
+  const issuesEl = document.getElementById('issues');
+  const tableBody = document.querySelector('#locatorTable tbody');
+
+  let lastResult = null;
+
+  async function process(xml) {
+    const elements = parse(xml);
+    const result = analyze(elements);
+    lastResult = result;
+    renderSummary(result.summary, summaryEl);
+    renderIssues(result.issues, issuesEl);
+    renderTable(result.elements, tableBody);
+  }
+
+  fileInput.addEventListener('change', async e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const text = await file.text();
+    process(text);
+  });
+
+  async function loadSample(path) {
+    const res = await fetch(path);
+    const text = await res.text();
+    process(text);
+  }
+
+  androidBtn.addEventListener('click', () => loadSample('assets/samples/sample_android.xml'));
+  iosBtn.addEventListener('click', () => loadSample('assets/samples/sample_ios.xml'));
+
+  document.getElementById('exportCsv').addEventListener('click', () => {
+    if (lastResult) exportCsv(lastResult.elements);
+  });
+  document.getElementById('exportJson').addEventListener('click', () => {
+    if (lastResult) exportJson(lastResult);
+  });
+  document.getElementById('printReport').addEventListener('click', () => {
+    printReport();
+  });
+}

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -1,0 +1,38 @@
+export function parseBounds(bounds) {
+  const match = /\[(\d+),(\d+)\]\[(\d+),(\d+)\]/.exec(bounds);
+  if (!match) return { x1: 0, y1: 0, x2: 0, y2: 0, width: 0, height: 0 };
+  const x1 = parseInt(match[1], 10);
+  const y1 = parseInt(match[2], 10);
+  const x2 = parseInt(match[3], 10);
+  const y2 = parseInt(match[4], 10);
+  return { x1, y1, x2, y2, width: x2 - x1, height: y2 - y1 };
+}
+
+export function isGenericId(id) {
+  return /^(btn|button|text|label)\d+$/i.test(id);
+}
+
+export function chunk(items, fn, done, chunkSize = 50) {
+  let index = 0;
+  function work(deadline) {
+    while (index < items.length && (deadline ? deadline.timeRemaining() > 0 : true)) {
+      fn(items[index], index);
+      index++;
+      if (chunkSize && index % chunkSize === 0) break;
+    }
+    if (index < items.length) {
+      if ('requestIdleCallback' in window) {
+        requestIdleCallback(work);
+      } else {
+        setTimeout(work, 0);
+      }
+    } else if (done) {
+      done();
+    }
+  }
+  if ('requestIdleCallback' in window) {
+    requestIdleCallback(work);
+  } else {
+    setTimeout(work, 0);
+  }
+}

--- a/assets/samples/sample_android.xml
+++ b/assets/samples/sample_android.xml
@@ -1,0 +1,9 @@
+<hierarchy>
+  <android.widget.FrameLayout index="0" package="com.example" content-desc="root" bounds="[0,0][300,300]">
+    <android.widget.Button index="0" resource-id="btn1" content-desc="" bounds="[0,0][50,40]" clickable="true" />
+    <android.widget.Button index="1" resource-id="btnSubmit" content-desc="submit" bounds="[0,50][100,110]" clickable="true" />
+    <android.widget.TextView index="2" resource-id="" content-desc="" bounds="[0,120][100,150]" clickable="false" />
+    <android.widget.Button index="3" resource-id="btnSubmit" content-desc="submit duplicate" bounds="[0,160][100,200]" clickable="true" />
+    <android.widget.Button index="4" resource-id="" content-desc="noid" bounds="[0,210][200,250]" clickable="true" />
+  </android.widget.FrameLayout>
+</hierarchy>

--- a/assets/samples/sample_ios.xml
+++ b/assets/samples/sample_ios.xml
@@ -1,0 +1,5 @@
+<AppiumAUT>
+  <XCUIElementTypeButton type="XCUIElementTypeButton" name="OK" label="OK" enabled="true" visible="true" x="0" y="0" width="100" height="30" />
+  <XCUIElementTypeButton type="XCUIElementTypeButton" name="" label="Cancel" enabled="true" visible="true" x="0" y="40" width="44" height="44" />
+  <XCUIElementTypeStaticText type="XCUIElementTypeStaticText" name="text1" label="Text" enabled="true" visible="true" x="0" y="90" width="100" height="20" />
+</AppiumAUT>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mobile Elements Report</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+  <link rel="stylesheet" href="assets/css/print.css" media="print">
+</head>
+<body>
+  <header>
+    <h1>Mobile Elements Report</h1>
+    <input type="file" id="xmlFile" accept=".xml">
+    <button id="loadAndroidSample">Load Android Sample</button>
+    <button id="loadIosSample">Load iOS Sample</button>
+  </header>
+  <main>
+    <section id="summary"></section>
+    <section id="issues"></section>
+    <section>
+      <h2>Locator Inventory</h2>
+      <table id="locatorTable">
+        <thead>
+          <tr><th>Type</th><th>ID</th><th>Accessibility ID</th><th>Bounds</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  </main>
+  <footer>
+    <button id="exportCsv">Export CSV</button>
+    <button id="exportJson">Export JSON</button>
+    <button id="printReport">Print</button>
+  </footer>
+  <script type="module" src="assets/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Parse Appium XML and analyze for missing accessibility IDs, generic IDs, duplicates, and small touch targets
- Render summary, issues, and locator table with chunked rendering
- Export report to CSV/JSON and print-friendly PDF with light theme

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a75bf6e53083289ce03c9e02fa4e96