### PR TITLE
Display element issues inline in locator table

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -44,10 +44,12 @@ section {
 
 .issue-warning {
   color: #ffb74d;
+  background: rgba(255, 183, 77, 0.1);
 }
 
 .issue-bad {
   color: #e57373;
+  background: rgba(229, 115, 115, 0.1);
 }
 
 button {

--- a/assets/js/analyzer.js
+++ b/assets/js/analyzer.js
@@ -11,26 +11,37 @@ export function analyze(elements) {
   const idMap = new Map();
   const accMap = new Map();
 
+  function addIssue(el, list, type, message) {
+    const entry = { type, message, element: el };
+    list.push(entry);
+    el.issues.push(message);
+    if (!el.severity || list === issues.bads) {
+      el.severity = list === issues.bads ? 'bad' : 'warning';
+    }
+  }
+
   elements.forEach(el => {
+    el.issues = [];
+    el.severity = null;
     if (!el.accId) {
-      issues.warnings.push({ type: 'missingAccId', message: 'Missing accessibility id', element: el });
+      addIssue(el, issues.warnings, 'missingAccId', 'Missing accessibility id');
     }
     if (el.clickable && !el.id) {
-      issues.warnings.push({ type: 'missingId', message: 'Interactive element missing id', element: el });
+      addIssue(el, issues.warnings, 'missingId', 'Interactive element missing id');
     }
     if (el.id && isGenericId(el.id)) {
-      issues.warnings.push({ type: 'genericId', message: `Generic id ${el.id}`, element: el });
+      addIssue(el, issues.warnings, 'genericId', `Generic id ${el.id}`);
     }
     if (el.id) {
       if (idMap.has(el.id)) {
-        issues.bads.push({ type: 'duplicateId', message: `Duplicate id ${el.id}`, element: el });
+        addIssue(el, issues.bads, 'duplicateId', `Duplicate id ${el.id}`);
       } else {
         idMap.set(el.id, true);
       }
     }
     if (el.accId) {
       if (accMap.has(el.accId)) {
-        issues.bads.push({ type: 'duplicateAccId', message: `Duplicate accessibility id ${el.accId}`, element: el });
+        addIssue(el, issues.bads, 'duplicateAccId', `Duplicate accessibility id ${el.accId}`);
       } else {
         accMap.set(el.accId, true);
       }
@@ -38,7 +49,7 @@ export function analyze(elements) {
     if (el.bounds) {
       const { width, height } = parseBounds(el.bounds);
       if (width < 48 || height < 48) {
-        issues.warnings.push({ type: 'smallTouch', message: `Small touch target ${width}x${height}`, element: el });
+        addIssue(el, issues.warnings, 'smallTouch', `Small touch target ${width}x${height}`);
       }
     }
   });

--- a/assets/js/exports.js
+++ b/assets/js/exports.js
@@ -9,10 +9,11 @@ function download(filename, content, type) {
 }
 
 export function exportCsv(elements) {
-  const header = 'type,id,accessibility_id,text,issues';
+  const header = 'text,id,accessibility_id,issue';
   const rows = elements.map(e => {
-    const text = (e.text || '').replace(/"/g, '""');
-    return `${e.type},${e.id},${e.accId},"${text}",${e.issues || ''}`;
+    const text = (e.text || e.type || '').replace(/"/g, '""');
+    const issue = e.issues ? e.issues.join('; ') : '';
+    return `"${text}",${e.id},${e.accId},"${issue}"`;
   });
   const csv = [header, ...rows].join('\n');
   download('report.csv', csv, 'text/csv');

--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -9,24 +9,14 @@ export function renderSummary(summary, container) {
   `;
 }
 
-export function renderIssues(issues, container) {
-  const warnItems = issues.warnings.map(i => `<li class="issue-warning">${i.message}</li>`).join('');
-  const badItems = issues.bads.map(i => `<li class="issue-bad">${i.message}</li>`).join('');
-  container.innerHTML = `
-    <h2>Issues</h2>
-    <h3>Warnings</h3>
-    <ul>${warnItems || '<li>None</li>'}</ul>
-    <h3>Bad</h3>
-    <ul>${badItems || '<li>None</li>'}</ul>
-  `;
-}
-
 export function renderTable(elements, tbody) {
   tbody.innerHTML = '';
   chunk(elements, el => {
     const tr = document.createElement('tr');
-    const issues = el.issues || '';
-    tr.innerHTML = `<td>${el.type}</td><td>${el.id}</td><td>${el.accId}</td><td>${el.text}</td><td>${issues}</td>`;
+    const text = el.text || el.type;
+    const issueText = el.issues ? el.issues.join('; ') : '';
+    const issueClass = el.severity ? `issue-${el.severity}` : '';
+    tr.innerHTML = `<td>${text}</td><td>${el.id}</td><td>${el.accId}</td><td class="${issueClass}">${issueText}</td>`;
     tbody.appendChild(tr);
   });
 }

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -1,6 +1,6 @@
 import { parse } from './parser.js';
 import { analyze } from './analyzer.js';
-import { renderSummary, renderIssues, renderTable } from './renderer.js';
+import { renderSummary, renderTable } from './renderer.js';
 import { exportCsv, exportJson, printReport } from './exports.js';
 
 export function setupUI() {
@@ -8,7 +8,6 @@ export function setupUI() {
   const androidBtn = document.getElementById('loadAndroidSample');
   const iosBtn = document.getElementById('loadIosSample');
   const summaryEl = document.getElementById('summary');
-  const issuesEl = document.getElementById('issues');
   const tableBody = document.querySelector('#locatorTable tbody');
 
   let lastResult = null;
@@ -18,7 +17,6 @@ export function setupUI() {
     const result = analyze(elements);
     lastResult = result;
     renderSummary(result.summary, summaryEl);
-    renderIssues(result.issues, issuesEl);
     renderTable(result.elements, tableBody);
   }
 

--- a/index.html
+++ b/index.html
@@ -16,12 +16,11 @@
   </header>
   <main>
     <section id="summary"></section>
-    <section id="issues"></section>
     <section>
       <h2>Locator Inventory</h2>
       <table id="locatorTable">
         <thead>
-          <tr><th>Type</th><th>ID</th><th>Accessibility ID</th><th>Text</th><th>Issues</th></tr>
+          <tr><th>Text</th><th>ID</th><th>Accessibility ID</th><th>Issue Identified</th></tr>
         </thead>
         <tbody></tbody>
       </table>


### PR DESCRIPTION
## Summary
- Drop separate issues section and show issues within the locator inventory table.
- Reorder locator table to `Text`, `ID`, `Accessibility ID`, and `Issue Identified`, coloring issue cells.
- Record element issues during analysis and update CSV export to match new layout.

## Testing
- `python3 -m http.server` *(followed by curl request)*

------
https://chatgpt.com/codex/tasks/task_e_68a7649634f483288574e635c5ed2038