### PR TITLE
Fix table rendering and restore type column

### DIFF
--- a/assets/js/exports.js
+++ b/assets/js/exports.js
@@ -9,11 +9,11 @@ function download(filename, content, type) {
 }
 
 export function exportCsv(elements) {
-  const header = 'text,id,accessibility_id,issue';
+  const header = 'text,id,accessibility_id,type,issue';
   const rows = elements.map(e => {
-    const text = (e.text || e.type || '').replace(/"/g, '""');
+    const text = (e.text || '').replace(/"/g, '""');
     const issue = e.issues ? e.issues.join('; ') : '';
-    return `"${text}",${e.id},${e.accId},"${issue}"`;
+    return `"${text}",${e.id},${e.accId},${e.type},"${issue}"`;
   });
   const csv = [header, ...rows].join('\n');
   download('report.csv', csv, 'text/csv');

--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -1,4 +1,4 @@
-import { chunk } from './utils.js';
+
 
 export function renderSummary(summary, container) {
   container.innerHTML = `
@@ -11,12 +11,12 @@ export function renderSummary(summary, container) {
 
 export function renderTable(elements, tbody) {
   tbody.innerHTML = '';
-  chunk(elements, el => {
+  elements.forEach(el => {
     const tr = document.createElement('tr');
-    const text = el.text || el.type;
+    const text = el.text || '';
     const issueText = el.issues ? el.issues.join('; ') : '';
     const issueClass = el.severity ? `issue-${el.severity}` : '';
-    tr.innerHTML = `<td>${text}</td><td>${el.id}</td><td>${el.accId}</td><td class="${issueClass}">${issueText}</td>`;
+    tr.innerHTML = `<td>${text}</td><td>${el.id}</td><td>${el.accId}</td><td>${el.type}</td><td class="${issueClass}">${issueText}</td>`;
     tbody.appendChild(tr);
   });
 }

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       <h2>Locator Inventory</h2>
       <table id="locatorTable">
         <thead>
-          <tr><th>Text</th><th>ID</th><th>Accessibility ID</th><th>Issue Identified</th></tr>
+          <tr><th>Text</th><th>ID</th><th>Accessibility ID</th><th>Type</th><th>Issue Identified</th></tr>
         </thead>
         <tbody></tbody>
       </table>


### PR DESCRIPTION
## Summary
- Ensure locator table rows render reliably by iterating elements directly
- Restore missing **Type** column in table and CSV export

## Testing
- `npx http-server` *(fails: 403 Forbidden to download package)*

------
https://chatgpt.com/codex/tasks/task_e_68a766ab044483288a42e3057773adcd